### PR TITLE
Fix URL HTTPS scheme to HTTP downgrade

### DIFF
--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -295,14 +295,18 @@ private
 
   def website_host
     begin
-      URI.parse(website).host
+      URI.parse(website_url).host
     rescue
     end
   end
 
   def website_url
     if object.website.present?
-      'http://%s' % object.website.sub(/^(https?:\/\/)?/, '')
+      if object.website.match /^https?:\/\//
+        object.website    
+      else
+        "http://%s" % object.website
+      end
     else
       nil
     end

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -38,9 +38,9 @@ class PersonDecorator < DbEntryDecorator
   end
 
   def website_html
-    if website_host.present?
-      h.link_to website_host, website_url, rel: 'nofollow', class: 'b-link'
-    end
+    return if website_host.blank?
+
+    h.link_to website_host, website_url, rel: 'nofollow', class: 'b-link'
   end
 
   def flatten_roles
@@ -294,14 +294,13 @@ private
   end
 
   def website_host
-    begin
-      URI.parse(website_url).host
-    rescue URI::Error
-    end
+    return if object.website.blank?
+    URI.parse(website_url).host
+  rescue URI::Error
   end
 
   def website_url
-    return nil if object.website.blank?
+    return if object.website.blank?
     if object.website.match?(%r{^https?://})
       object.website
     else

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -296,19 +296,16 @@ private
   def website_host
     begin
       URI.parse(website_url).host
-    rescue
+    rescue URI::Error
     end
   end
 
   def website_url
-    if object.website.present?
-      if object.website.match /^https?:\/\//
-        object.website    
-      else
-        "http://%s" % object.website
-      end
+    return nil if object.website.blank?
+    if object.website.match?(%r{^https?://})
+      object.website
     else
-      nil
+      "http://#{object.website}"
     end
   end
 

--- a/app/decorators/user_profile_decorator.rb
+++ b/app/decorators/user_profile_decorator.rb
@@ -19,10 +19,9 @@ class UserProfileDecorator < UserDecorator
   end
 
   def website
-    return '' if object.website.blank?
+    return '' if website_host.blank?
 
-    url_wo_http = h.h(object.website).sub(/^https?:\/\//, '')
-    h.link_to url_wo_http.sub(/\/.*/, ''), "http://#{url_wo_http}", class: 'website'
+    h.link_to h.h(website_host), h.h(website_url), class: 'website'
   end
 
   def about_html
@@ -219,6 +218,24 @@ private
 
     else
       h.l created_at, format: i18n_t('registration_formats.year')
+    end
+  end
+
+  def website_host
+    begin
+      URI.parse(website_url).host
+    rescue
+    end
+  end
+
+  def website_url
+    if object.website.blank?
+      nil
+    end
+    unless object.website.match /^https?:\/\//
+      "http://%s" % object.website
+    else
+      object.website
     end
   end
 end

--- a/app/decorators/user_profile_decorator.rb
+++ b/app/decorators/user_profile_decorator.rb
@@ -232,10 +232,10 @@ private
     if object.website.blank?
       nil
     end
-    unless object.website.match /^https?:\/\//
-      "http://%s" % object.website
-    else
+    if object.website.match?(%r{^https?://})
       object.website
+    else
+      "http://#{object.website}"
     end
   end
 end

--- a/app/decorators/user_profile_decorator.rb
+++ b/app/decorators/user_profile_decorator.rb
@@ -228,7 +228,7 @@ private
   end
 
   def website_url
-    return nil if object.website.blank?
+    return if object.website.blank?
     if object.website.match?(%r{^https?://})
       object.website
     else

--- a/app/decorators/user_profile_decorator.rb
+++ b/app/decorators/user_profile_decorator.rb
@@ -222,16 +222,13 @@ private
   end
 
   def website_host
-    begin
-      URI.parse(website_url).host
-    rescue
-    end
+    return if object.website.blank?
+    URI.parse(website_url).host
+  rescue URI::Error
   end
 
   def website_url
-    if object.website.blank?
-      nil
-    end
+    return nil if object.website.blank?
     if object.website.match?(%r{^https?://})
       object.website
     else


### PR DESCRIPTION
Website URL scheme in user and person profiles is forced to be HTTP instead of HTTPS.
Such behavior is insecure and inconvenient since most websites are now HTTPS-only, with some of them even serving different content on 80 and 443 TCP ports.

This patch tries to leave `https://` in the URLs, while preserving the old behavior by prepending `http://` to all non-HTTP(S) URLs.

Please, let me know if I've missed something, e.g. something like [UserProfileSerializer] — I'm not sure if it should be modified too.

[UserProfileSerializer]: https://github.com/shikimori/shikimori/blob/master/app/serializers/user_profile_serializer.rb