### PR TITLE
Fix male gender regression

### DIFF
--- a/app/decorators/user_profile_decorator.rb
+++ b/app/decorators/user_profile_decorator.rb
@@ -90,8 +90,10 @@ class UserProfileDecorator < UserDecorator
 
     if h.can? :access_list, self
       info << h.h(name)
-      info << i18n_t('male') if male?
-      info << i18n_t('female') if female?
+      unless object.sex.blank?
+        info << i18n_t('male') if male?
+        info << i18n_t('female') if female?
+      end
       unless object.birth_on.blank?
         info << "#{full_years} #{i18n_i 'years_old', full_years}" if full_years > 12
       end


### PR DESCRIPTION
This PR fixes the regression caused by commit dad9d6b0c60d6a6b7bd8323afb25f8cae1a91e45 — users that *did not* specify the `sex` field (and their personal information is not hidden) have *male*/*муж* on their profile pages.