### PR TITLE
fix 404 page's height

### DIFF
--- a/app/assets/stylesheets/page404.sass
+++ b/app/assets/stylesheets/page404.sass
@@ -26,7 +26,8 @@ html
       font-weight: normal
 
     .dialog
-      margin: 40px auto 0
+      margin: 0 auto
+      padding-top: 40px
       max-width: 600px
 
     p


### PR DESCRIPTION
Due adjoining margins .dialog margin adds 40px to body height causing page scroll