### PR TITLE
Fix docs 'appears' typo

### DIFF
--- a/app/controllers/api/v1/appear_controller.rb
+++ b/app/controllers/api/v1/appear_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::AppearController < Api::V1Controller
   before_action :authenticate_user!
 
-  api :POST, '/appear', 'Mark comments or topics as read'
+  api :POST, '/appears', 'Mark comments or topics as read'
   param :ids, :undef
   def create
     return head 200 unless params[:ids]


### PR DESCRIPTION
Fixed a typo in documentation. Provided /api/appear endpoint isn't available.
![d](https://i.imgur.com/Vg9iNo1.png)
![pic](https://i.imgur.com/zPtn5DV.png)