### PR TITLE
Добавил новые мета-тега (пока в формате эксперимента для первой 1000 айдишников)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-debug.log*
 yarn-error.log
 .yarn-integrity
 package-lock.json
+
+.idea

--- a/app/controllers/db_entries_controller.rb
+++ b/app/controllers/db_entries_controller.rb
@@ -180,6 +180,10 @@ private
     end
     if @resource.anime? && @resource.id <= 1000
       og image: "http://cdn.anime-recommend.ru/previews/#{@resource.id}.jpg"
+      og image_width: 1200
+      og image_height: 630
+      og image_type: 'image/jpeg'
+      og twitter_card: 'summary_large_image'
     else
       og image: ImageUrlGenerator.instance.url(@resource, :original)
     end

--- a/app/view_objects/open_graph_view.rb
+++ b/app/view_objects/open_graph_view.rb
@@ -1,11 +1,14 @@
 class OpenGraphView < ViewObjectBase
   attr_reader :page_title
   attr_writer :description, :canonical_url
-  attr_accessor :type, :image,
-    :video_duration, :video_release_date, :video_tags,
-    :book_release_date, :book_tags,
-    :notice,
-    :keywords, :noindex, :nofollow
+  attr_accessor :type, :image, :image_type,
+                :image_width,
+                :image_height,
+                :twitter_card,
+                :video_duration, :video_release_date, :video_tags,
+                :book_release_date, :book_tags,
+                :notice,
+                :keywords, :noindex, :nofollow
 
   PAGE_TITLE_SEPARATOR = ' / '
 

--- a/app/views/application/_head.html.slim
+++ b/app/views/application/_head.html.slim
@@ -76,6 +76,12 @@ meta property='og:title' content=og.headline(true)
   meta property='og:description' content=og.description
 - if og.image
   meta property='og:image' content=og.image
+- if og.image_type
+  meta property='og:image:type' content=og.image_type
+- if og.image_width
+  meta property='og:image:width' content=og.image_width
+- if og.image_height
+  meta property='og:image:height' content=og.image_height
 meta property='og:url' content==og.canonical_url
 meta property='og:site_name' content=og.site_name
 
@@ -92,6 +98,8 @@ meta property='og:site_name' content=og.site_name
   - og.book_tags.each do |tag|
     meta property='book:tag' content=tag
 
+- if og.twitter_card
+  meta property='twitter:card' content=og.twitter_card
 meta name='twitter:title' content=og.headline(true)
 - if og.description.present?
   meta name='twitter:description' content=og.description
@@ -125,7 +133,7 @@ script[
 - unless Rails.env.test?
   / = stylesheet_pack_tag 'vendor', media: 'all', data: { 'turbolinks-track' => 'reload'  }
   / = stylesheet_pack_tag 'application', media: 'all', data: { 'turbolinks-track' => 'reload'  }
-  = stylesheet_pack_tag 'vendors', media: 'all', data: { 'turbolinks-track' => 'reload'  }
+  = stylesheet_pack_tag 'vendors', media: 'all', data: { 'turbolinks-track' => 'reload' }
   = stylesheet_link_tag :application, media: 'all', data: { 'turbolinks-track' => 'reload' }
 
   = yield :head


### PR DESCRIPTION
## Что и зачем
```slim
- if og.image_width
  meta property='og:image:width' content=og.image_width
- if og.image_height
  meta property='og:image:height' content=og.image_height
```
Нужны Фейсбуку/VK, чтобы:
>Use og:image:width and og:image:height Open Graph tags to specify the image dimensions to the crawler so that it can render the image **immediately** without having to asynchronously download and process it.

![facebook](https://user-images.githubusercontent.com/34550675/156584037-b66d68b7-637a-43e6-9630-791d40ebf318.png)
![vk](https://user-images.githubusercontent.com/34550675/156584045-1e485b97-8cd0-4d63-bc93-fe9a1e5a50c4.png)


```slim
- if og.image_type
  meta property='og:image:type' content=og.image_type
```

Не до конца уверен зачем, но именно после него у меня начало рендериться в телеге:
<img width="366" alt="telegram" src="https://user-images.githubusercontent.com/34550675/156584042-8fb9763c-09e1-408c-80eb-d6123cbb634f.png">

```slim
- if og.twitter_card
  meta property='twitter:card' content=og.twitter_card
```
А именно в значении `summary_large_image`, делает огромную превью в Твиттере:
![twitter](https://user-images.githubusercontent.com/34550675/156584033-918985b6-e54a-4c7a-9b5b-043d963ca97d.png)


## Проблемы
1. Почему-то VK отрезает нижнюю часть. Каких-то специфичных подходов к нему я не нашел, но там не видно только логотип Шикимори (впрочем недалеко видно ссылку на shikimori.one)
2. Это первый раз, когда я что-то писал на Руби. За кривые отступы/подходы - прошу простить. Я быстро учусь, если поправлять 
