### PR TITLE
Fix `required` flag typo and condition of `image` parameter in /api/user_images

### DIFF
--- a/app/controllers/api/v1/user_images_controller.rb
+++ b/app/controllers/api/v1/user_images_controller.rb
@@ -8,8 +8,8 @@ class Api::V1::UserImagesController < Api::V1Controller
 
   api :POST, '/user_images', 'Create an user image'
   description 'Requires `comments` oauth scope'
-  param :image, :undef, require: true
-  param :linked_type, String, require: true
+  param :image, :undef, required: true
+  param :linked_type, String, required: true
   def create # rubocop:disable all
     dev_user = User.find params[:test] if test_upload_request?
 

--- a/app/controllers/api/v1/user_images_controller.rb
+++ b/app/controllers/api/v1/user_images_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::UserImagesController < Api::V1Controller
   api :POST, '/user_images', 'Create an user image'
   description 'Requires `comments` oauth scope'
   param :image, :undef, required: true
-  param :linked_type, String, required: true
+  param :linked_type, String, required: false
   def create # rubocop:disable all
     dev_user = User.find params[:test] if test_upload_request?
 


### PR DESCRIPTION
Because of this typo, the documentation showed that `image` parameter is optional instead of required. 
Also `require` flags have been changed to correct ones

Closes #2428