### PR TITLE
Fix verb for /api/user_rates/:type/reset example

### DIFF
--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -5229,7 +5229,7 @@
   ],
   "user_rates#reset": [
     {
-      "verb": "POST",
+      "verb": "DELETE",
       "path": "/api/user_rates/anime/reset",
       "versions": [
         "1.0"


### PR DESCRIPTION
Fix an incorrect verb in the documentation example for the /api/user_rates/:type/reset method
<img width="598" alt="image" src="https://user-images.githubusercontent.com/36604233/183072316-fd2ce862-434b-4ac1-87b0-4bebf8fc06c7.png">
