### PR TITLE
Update shiki_editor.ru.yml

### DIFF
--- a/config/locales/frontend/shiki_editor.en.yml
+++ b/config/locales/frontend/shiki_editor.en.yml
@@ -22,6 +22,7 @@ en:
       spoiler_block: Spoiler block
       code_block: Code block
       bullet_list: List
+      headline: Headline
       blockquote: Quote
       prompt:
         image_url: Image URL

--- a/config/locales/frontend/shiki_editor.ru.yml
+++ b/config/locales/frontend/shiki_editor.ru.yml
@@ -22,6 +22,7 @@ ru:
       spoiler_block: Блок спойлера
       code_block: Блок кода
       bullet_list: Список
+      headline: Заголовок
       blockquote: Цитата
       prompt:
         image_url: URL картинки


### PR DESCRIPTION
Собственно, отсутствует локализация для кнопки в Shiki Editor, связанная с заголовками.