### PR TITLE
fix conflicting styles on contest result page

### DIFF
--- a/app/assets/stylesheets/blocks/b-catalog_entry.sass
+++ b/app/assets/stylesheets/blocks/b-catalog_entry.sass
@@ -13,7 +13,7 @@ $max_width: 167px
   max-width: 460px
 
   &.cc
-    .cover
+    & > .cover
       +column(2, 0.4)
     .content
       +column(2, 0.6)


### PR DESCRIPTION
Подробности проблемы: https://shikimori.one/comments/9243027

Желательно, конечно, везде указывать `.cover` как дочерний элемент, но и такого изменения достаточно, чтобы решить данный конфликт.