### PR TITLE
Pre-build GA image

### DIFF
--- a/.github/workflows/prepare-rspec-image.yml
+++ b/.github/workflows/prepare-rspec-image.yml
@@ -1,0 +1,28 @@
+name: Prepare RSpec Docker image
+
+on:
+  push:
+    paths:
+      - 'config/rspec/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    defaults:
+      run:
+        working-directory: './config/rspec/v1.0.0'
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@main
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: 'Build'
+        run: |
+          docker build . --tag ghcr.io/shikimori/rspec:v1.0.0
+          docker push ghcr.io/shikimori/rspec:v1.0.0

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,27 +6,18 @@ on:
   pull_request:
     branches:
       - '*'
-jobs:
-  # rubocop:
-  #   name: Rubocop
-  #   runs-on: 'ubuntu-20.04'
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ruby/setup-ruby@v1
-  #       with:
-  #         ruby-version: '3.0'
-  #     - run: script/update_rubygems_and_install_bundler
-  #     - run: bundle install --standalone
-  #     - run: bundle binstubs --all
-  #     - run: script/run_rubocop
 
+jobs:
   RSpec:
-    # strategy:
-    #   matrix:
-    #     node-version: [14.x]
-    #     redis-version: [6]
     runs-on: 'ubuntu-22.04'
+    container:
+      image: ghcr.io/shikimori/rspec:v1.0.0
+      credentials:
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
     services:
+      redis:
+        image: redis:6
       postgres:
         image: postgres:10.5-alpine
         ports:
@@ -35,24 +26,14 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
     env:
+      POSTGRES_TEST_HOST: postgres
       POSTGRES_TEST_USER: postgres
       POSTGRES_TEST_PASSWORD: postgres
       POSTGRES_TEST_DB: github-actions
+      REDIS_HOST: redis
       RAILS_ENV: test
       CI_SERVER: yes
     steps:
-      - name: Install dependencies
-        run: sudo apt-get install -y libvips imagemagick libjpeg-progs
-      - name: Start Redis
-        uses: supercharge/redis-github-action@1.4.0
-        with:
-          redis-version: 6
-          # redis-version: ${{ matrix.redis-version }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-          # node-version: ${{ matrix.node-version }}
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Ruby and gems

--- a/config/application.rb
+++ b/config/application.rb
@@ -173,7 +173,7 @@ module Shikimori
     # fixes numerous errors on production
     config.active_record.yaml_column_permitted_classes = [Time]
 
-    config.redis_host = 'localhost'
+    config.redis_host = ENV['REDIS_HOST'] ? ENV['REDIS_HOST'] : 'localhost'
     config.redis_db = 2
 
     # достали эксепшены с ханибаджера

--- a/config/rspec/v1.0.0/Dockerfile
+++ b/config/rspec/v1.0.0/Dockerfile
@@ -5,15 +5,23 @@ ARG NODE_VERSION=14.21.3
 LABEL org.opencontainer.image.source="https://github.com/shikimori/shikimori/blob/master/config/rspec/v1.0.0/Dockerfile"
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV TZ "Europe/Moscow"
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
         build-essential \
         ca-certificates \
+        ruby \
+        libpq-dev \
         curl \
+        file \
         gnupg \
         libvips \
         imagemagick \
+        make \
+        unzip \
+        tzdata \
         libjpeg-progs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -29,7 +37,7 @@ RUN . ${NVM_DIR}/nvm.sh && \
     nvm install ${NODE_VERSION} && \
     nvm alias default ${NODE_VERSION} && \
     nvm use default
-ENV PATH ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
+ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
 # Verify node and npm installation
 RUN node --version && \
@@ -41,6 +49,8 @@ RUN curl -fsSL https://get.docker.com | bash
 FROM ubuntu:22.04
 COPY --from=buildtool / /
 
+ARG NODE_VERSION=14.21.3
+
 ENV HOME /root
 ENV NVM_DIR /root/.nvm
-ENV PATH ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
+ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}"

--- a/config/rspec/v1.0.0/Dockerfile
+++ b/config/rspec/v1.0.0/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:22.04 as buildtool
+
+ARG NODE_VERSION=14.21.3
+
+LABEL org.opencontainer.image.source="https://github.com/shikimori/shikimori/blob/master/config/rspec/v1.0.0/Dockerfile"
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        build-essential \
+        ca-certificates \
+        curl \
+        gnupg \
+        libvips \
+        imagemagick \
+        libjpeg-progs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+ENV NVM_DIR /root/.nvm
+
+# Install node
+RUN . ${NVM_DIR}/nvm.sh && \
+    nvm install ${NODE_VERSION} && \
+    nvm alias default ${NODE_VERSION} && \
+    nvm use default
+ENV PATH ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}
+
+# Verify node and npm installation
+RUN node --version && \
+    npm --version
+
+# Install Docker
+RUN curl -fsSL https://get.docker.com | bash
+
+FROM ubuntu:22.04
+COPY --from=buildtool / /
+
+ENV HOME /root
+ENV NVM_DIR /root/.nvm
+ENV PATH ${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}


### PR DESCRIPTION
_Ого, я таки смог это сделать_

**Проблема:**
Я заметил что `RSpec` экшн [падает](https://github.com/shikimori/shikimori/actions/runs/6997298342/job/19034111961) из-за версий/нетворкинга:
>Err:27 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 libpoppler118 amd64 22.02.0-2ubuntu0.2
  404  Not Found [IP: 52.252.75.106 80]
Ign:28 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 libpoppler-glib8 amd64 22.02.0-2ubuntu0.2
Err:28 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 libpoppler-glib8 amd64 22.02.0-2ubuntu0.2
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/p/poppler/libpoppler118_22.02.0-2ubuntu0.2_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
Fetched 14.3 MB in 1s (11.0 MB/s)
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/p/poppler/libpoppler-glib8_22.02.0-2ubuntu0.2_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

Я подумал что можно заморозить утилиты/версии в одном месте, и никогда об этом не вспоминать.

**Решение:**
- Докер-образ `config/rspec/v1.0.0/Dockerfile` содержит всё необходимое для запуска Гитхаб-экшена. (либы, постгря, руби, нода)
- GA `.github/workflows/prepare-rspec-image.yml` следит за изменениями в директории `'config/rspec/**'` и собирает образ, если есть какие-то изменения. После билда образ пушится в Гитхаб - `ghcr.io/shikimori/rspec:v1.0.0`
- GA `.github/workflows/rspec.yml` использует `ghcr.io/shikimori/rspec:v1.0.0` как основной контейнер, минимизируя время запуска (ну и для воспроизводимости полезно)

Не уверен, плохо это или хорошо, но этот образ отображается в репо Шикимори. (вроде как это можно выключить в настройках репозитория)
![Screenshot 2023-11-27 at 17 57 28](https://github.com/shikimori/shikimori/assets/34550675/1fc1db15-e039-4d42-aa50-a8344353f8ac)


**Если нужно будет обновить/добавить что-то:**
- Создайте новый файлик, например `config/rspec/v1.0.1/Dockerfile`
- Добавьте всё, что хочется
- Обновите путь до файла И версию образа в `.github/workflows/*`
- Готово! Следующий запуск будет на обновлённом окружении