### PR TITLE
fix: correct names for status type for Anime/Manga queries

### DIFF
--- a/app/graphql/types/scalars/anime/status_string.rb
+++ b/app/graphql/types/scalars/anime/status_string.rb
@@ -1,4 +1,4 @@
 class Types::Scalars::Anime::StatusString < Types::StringType
-  graphql_name 'MangaStatusString'
+  graphql_name 'AnimeStatusString'
   i18n_comma_separeted_description 'enumerize.anime.status'
 end

--- a/app/graphql/types/scalars/manga/status_string.rb
+++ b/app/graphql/types/scalars/manga/status_string.rb
@@ -1,4 +1,4 @@
 class Types::Scalars::Manga::StatusString < Types::StringType
-  graphql_name 'AnimeStatusString'
+  graphql_name 'MangaStatusString'
   i18n_comma_separeted_description 'enumerize.manga.status'
 end


### PR DESCRIPTION
У `status` для квери `animes` и `mangas` были перепутаны названия

<img width="267" alt="image" src="https://github.com/shikimori/shikimori/assets/36604233/9bfed601-2232-4c5c-904f-ff73930905d0">
<img width="246" alt="image" src="https://github.com/shikimori/shikimori/assets/36604233/8fcaf7d6-9b8a-4f9d-9961-a252d8b67bb5">
