### PR TITLE
Add new css variable for icon color

### DIFF
--- a/app/assets/stylesheets/blocks/b-subposter-actions.sass
+++ b/app/assets/stylesheets/blocks/b-subposter-actions.sass
@@ -10,7 +10,7 @@
     flex-direction: column
 
 .b-subposter-action
-  +link_color(#444)
+  +link_color(var(--icon-color))
   cursor: pointer
   display: inline-block
   height: $icon_mobile_size

--- a/app/assets/stylesheets/mixins/icons.sass
+++ b/app/assets/stylesheets/mixins/icons.sass
@@ -56,7 +56,7 @@ $icon_mobile_size: 30px
 
 =icon_button($content)
   +icon($content, 13px)
-  +link_color(#444)
+  +link_color(var(--icon-color))
   +icon_left_margins
 
   &.selected

--- a/app/assets/stylesheets/themes/light.sass
+++ b/app/assets/stylesheets/themes/light.sass
@@ -1,4 +1,5 @@
 html[data-color-mode=light]
+  --icon-color: #444
   --link-color: #176093
   --link-hover-color: #dd5202
   --link-active-color: #ff0202


### PR DESCRIPTION
На сайте множество других иконок, которые используют другой цвет ([вроде такого](https://github.com/shikimori/shikimori/blob/master/app/assets/stylesheets/blocks/b-status-line.sass#L17)) или не имеют своего отдельного свойства для цвета иконки и используют цвет текста ([как тут](https://github.com/shikimori/shikimori/blob/master/app/assets/stylesheets/blocks/b-news_wall-topic.sass#L67)) — ничего из этого я не трогал. Можно потом сделать отдельные переменные для этих цветов или переделать под один общий цвет.