### PR TITLE
fix profile edit link at 481~767px

### DIFF
--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -115,9 +115,9 @@
       - if @view.own_profile?
         a href=profile_dialogs_url(@resource)
           = t '.my_mail'
-        a href=profile_list_history_url(@resource)
+        a.history-action href=profile_list_history_url(@resource)
           = i18n_io 'History', :one
-        a.history-action href=@resource.edit_url(section: :account)
+        a href=@resource.edit_url(section: :account)
           = t '.my_profile_settings'
         a href=moderation_profile_url(@resource)
           = t '.my_bans'


### PR DESCRIPTION
Вместо ссылки на историю, скрывается ссылка на редактирование профиля из-за неправильно указанного класса на этой ссылке. P.S. Ничего не тестировал, должно и так работать.. 🙄

https://github.com/shikimori/shikimori/blob/970dcb7080c249cbccf50e1503a9395f6d1945b5/app/assets/stylesheets/pages/p-profiles/_head.sass#L123-L125

<details><summary>Скриншот</summary>
<p>

![shikimori one_grin3671](https://github.com/user-attachments/assets/3e9ac223-443c-4736-8d8e-a38ac310d054)

</p>
</details>
